### PR TITLE
remove duplicate headers from Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,6 @@ unit_tests_CXXFLAGS = -DUNITTEST -DNDEBUG -std=c++0x -I src/
 unit_tests_LDADD= -lcppunit -ldl
 
 include_HEADERS = src/sim_gt.hpp src/plot/figure.hpp src/freq/freq.hpp src/hybridLambda.hpp src/node.hpp src/net.hpp src/global.hpp \
-				  src/fastfunc.hpp  src/hybridLambda.hpp src/random_generator.hpp src/global.hpp src/mersenne_twister.hpp \
-				  src/node.hpp  src/regular_math.hpp
+	  src/fastfunc.hpp  src/random_generator.hpp src/mersenne_twister.hpp \
+	  src/regular_math.hpp
 


### PR DESCRIPTION
src/hybridLambda.hpp src/global.hpp, and src/node.hpp were each listed
twice, causing the build to fail under Linux.